### PR TITLE
Fix to account for created empty words

### DIFF
--- a/jquery.textillate.js
+++ b/jquery.textillate.js
@@ -166,7 +166,9 @@
             })
             .each(function () { $(this).lettering() });
       }
-
+      
+      $('span[class^="word"]:empty').css("display", "none");
+       
       $tokens = base.$current
         .find('[class^="' + base.options.type + '"]')
         .css('display', 'inline-block');


### PR DESCRIPTION
I already sent a contribution to lettering.js to fix the bug that doesn't account for html and creates extraneous words due to lack of trimming. However if they choose not to use that update, I am sending you a line of code( it's on line 170 ) that tests for empty words with no chars and sets 'display: none' so that they at least do not cause spacing/formatting issues.
